### PR TITLE
Merge wp-media-picker-compatibility into master

### DIFF
--- a/js/uri-boxout-plugin.js
+++ b/js/uri-boxout-plugin.js
@@ -63,10 +63,10 @@
 						{type: 'textbox', name: 'title', label: 'Title', value: args.title},
 						{type: 'textbox', multiline: 'true', name: 'content', label: 'Content', value: args.content},
 						{type: 'listbox', name: 'float', label: 'Alignment', value: args.float, 'values': [
-						{text: 'Auto', value: ''},
-						{text: 'Left', value: 'left'},
-						{text: 'Right', value: 'right'}
-					]
+							{text: 'Auto', value: ''},
+							{text: 'Left', value: 'left'},
+							{text: 'Right', value: 'right'}
+						]
 						},
 					],
 					onsubmit: function(e) {

--- a/js/uri-boxout-plugin.js
+++ b/js/uri-boxout-plugin.js
@@ -3,11 +3,7 @@
 (function() {
 
 	var cName = 'cl-boxout',
-			wName = 'CLBoxout';
-    
-	function renderBoxout( shortcode ) {
-	}
-
+		wName = 'CLBoxout';
 	
 	function generateBoxoutShortcode(params) {
 
@@ -47,7 +43,7 @@
 			});
 		
 			// add a js callback for the button
-			ed.addCommand(wName, function(args) {
+			ed.addCommand(wName, function( target, args ) {
 			
 				// create an empty object if args is empty
 				if(!args) {
@@ -86,7 +82,7 @@
 			});
             
 			ed.on( 'BeforeSetContent', function( event ) {
-				event.content = URIWYSIWYG.replaceShortcodes( event.content, cName, false, renderBoxout, this );
+				event.content = URIWYSIWYG.replaceShortcodes( event.content, cName, false, ed );
 			});
 
 			ed.on( 'PostProcess', function( event ) {

--- a/js/uri-button-plugin.js
+++ b/js/uri-button-plugin.js
@@ -3,12 +3,7 @@
 (function() {
    
 	var cName = 'cl-button',
-			wName = 'CLButton';
-	
-
-	function renderButton( shortcode, ed ) {
-
-	}
+		wName = 'CLButton';
 	
 	function generateButtonShortcode(params) {
 
@@ -54,7 +49,7 @@
 			});
 		
 			// add a js callback for the button
-			ed.addCommand(wName, function(args) {
+			ed.addCommand(wName, function( target, args ) {
 			
 				// create an empty object if args is empty
 				if(!args) {
@@ -91,7 +86,7 @@
 			});
 
 			ed.on( 'BeforeSetContent', function( event ) {
-				event.content = URIWYSIWYG.replaceShortcodes( event.content, cName, true, renderButton, this );
+				event.content = URIWYSIWYG.replaceShortcodes( event.content, cName, true, this );
 			});
 
 			ed.on( 'PostProcess', function( event ) {

--- a/js/uri-button-plugin.js
+++ b/js/uri-button-plugin.js
@@ -56,7 +56,7 @@
 					args = {}
 				}
 				// create an empty property so nothing is null
-				var possibleArgs = ['link', 'text', 'tooltip', 'prominent'];
+				var possibleArgs = ['link', 'text', 'tooltip', 'style'];
 				possibleArgs.forEach(function(i){
 					if(!args[i]) {
 						args[i] = '';
@@ -71,7 +71,12 @@
 						{type: 'textbox', name: 'link', label: 'Link', value: args.link},
 						{type: 'textbox', name: 'text', label: 'Text', 'placeholder':'Explore', value: args.text},
 						{type: 'textbox', name: 'tooltip', label: 'Tooltip', value: args.tooltip},
-						{type: 'checkbox', name: 'prominent', label: 'Prominent', checked: (args.style == 'prominent') },
+						{type: 'listbox', name: 'style', label: 'Style', value: args.style, 'values': [
+							{text: 'Default', value: ''},
+							{text: 'Prominent', value: 'prominent'},
+							{text: 'Disabled', value: 'disabled'}
+						]
+						},
 					],
 					onsubmit: function(e) {
 						// Insert content when the window form is submitted

--- a/js/uri-card-plugin.js
+++ b/js/uri-card-plugin.js
@@ -52,7 +52,9 @@
 			});
 		
 			// add a js callback for the button
-			ed.addCommand(wName, function(args) {
+			ed.addCommand(wName, function(target, args) {
+				
+				console.log(target, args);
 			
 				// create an empty object if args is empty
 				if(!args) {
@@ -96,7 +98,14 @@
 					onsubmit: function(e) {
 						// Insert content when the window form is submitted
 						shortcode = generateCardShortcode(e.data);
-						ed.execCommand('mceInsertContent', 0, shortcode);
+						if ( target ) {
+							var id = URIWYSIWYG.generateID();
+							console.log('generated', id);
+							jQuery(target).replaceWith('<div class="loading" data-shortcode="' + window.encodeURIComponent( shortcode ) + '" id="' + id + '">Loading...</div>');
+							URIWYSIWYG.getHTML( ed, shortcode, id, 'mceNonEditable ' + cNames[0] );
+						} else {
+							ed.execCommand('mceInsertContent', 0, shortcode);
+						}
 					}
 				},
 				{
@@ -106,6 +115,7 @@
 			});
 
 			ed.on( 'BeforeSetContent', function( event ) {
+				console.log(event);
 				for (var i=0; i<cNames.length; i++) {
 					event.content = URIWYSIWYG.replaceShortcodes( event.content, cNames[i], true, renderCard, ed );
 				}

--- a/js/uri-card-plugin.js
+++ b/js/uri-card-plugin.js
@@ -49,7 +49,7 @@
 			});
 		
 			// add a js callback for the button
-			ed.addCommand(wName, function(target, args) {
+			ed.addCommand(wName, function( target, args ) {
 							
 				// create an empty object if args is empty
 				if(!args) {
@@ -92,17 +92,8 @@
 					],
 					onsubmit: function(e) {
 						// Insert content when the window form is submitted
-						shortcode = generateCardShortcode(e.data);
-						if ( target ) {
-							var id = URIWYSIWYG.generateID();
-							jQuery(target).replaceWith( URIWYSIWYG.generateLoadingDiv( window.encodeURIComponent( shortcode ), id ) );
-							
-							for (var i=0; i<cNames.length; i++) {
-								URIWYSIWYG.getHTML( ed, shortcode, id, 'mceNonEditable ' + cNames[i] );
-							}
-						} else {
-							ed.execCommand('mceInsertContent', 0, shortcode);
-						}
+						var shortcode = generateCardShortcode(e.data);
+						URIWYSIWYG.insertMultiMediaComponent( target, shortcode, ed, cNames );
 					}
 				},
 				{

--- a/js/uri-card-plugin.js
+++ b/js/uri-card-plugin.js
@@ -2,11 +2,8 @@
 
 (function() {
     
-	var cNames = ['cl-card'],
-			wName = 'CLCard';
-
-	function renderCard( shortcode ) {
-	}
+	var cNames = ['cl-card', 'cl-dcard'],
+		wName = 'CLCard';
 	
 	function generateCardShortcode(params) {
 
@@ -53,9 +50,7 @@
 		
 			// add a js callback for the button
 			ed.addCommand(wName, function(target, args) {
-				
-				console.log(target, args);
-			
+							
 				// create an empty object if args is empty
 				if(!args) {
 					args = {style:'', title:'', body:'', link:''}
@@ -100,9 +95,11 @@
 						shortcode = generateCardShortcode(e.data);
 						if ( target ) {
 							var id = URIWYSIWYG.generateID();
-							console.log('generated', id);
-							jQuery(target).replaceWith('<div class="loading" data-shortcode="' + window.encodeURIComponent( shortcode ) + '" id="' + id + '">Loading...</div>');
-							URIWYSIWYG.getHTML( ed, shortcode, id, 'mceNonEditable ' + cNames[0] );
+							jQuery(target).replaceWith( URIWYSIWYG.generateLoadingDiv( window.encodeURIComponent( shortcode ), id ) );
+							
+							for (var i=0; i<cNames.length; i++) {
+								URIWYSIWYG.getHTML( ed, shortcode, id, 'mceNonEditable ' + cNames[i] );
+							}
 						} else {
 							ed.execCommand('mceInsertContent', 0, shortcode);
 						}
@@ -115,9 +112,8 @@
 			});
 
 			ed.on( 'BeforeSetContent', function( event ) {
-				console.log(event);
 				for (var i=0; i<cNames.length; i++) {
-					event.content = URIWYSIWYG.replaceShortcodes( event.content, cNames[i], true, renderCard, ed );
+					event.content = URIWYSIWYG.replaceShortcodes( event.content, cNames[i], true, ed );
 				}
 			});
 

--- a/js/uri-card-plugin.js
+++ b/js/uri-card-plugin.js
@@ -56,7 +56,7 @@
 					args = {style:'', title:'', body:'', link:''}
 				}
 				// create an empty property so nothing is null
-				var possibleArgs = ['title', 'body', 'link', 'button', 'img', 'alt', 'tooltip'];
+				var possibleArgs = ['title', 'body', 'link', 'button', 'img', 'alt', 'tooltip', 'float'];
 				if(!args.title) {
 					args.title = '';
 				}
@@ -88,7 +88,13 @@
 						{type: 'textbox', name: 'alt', id: 'alt', value: args.alt, subtype: 'hidden'},
 						{type: 'textbox', name: 'img', id: 'img', value: args.img, subtype: 'hidden'},
 						{type: 'container', label: ' ', html: '<div id="wysiwyg-img-preview">' + imageEl + '</div>'},
-						{type: 'button', label: 'Image', text: 'Choose an image', onclick: URIWYSIWYG.mediaPicker}
+						{type: 'button', label: 'Image', text: 'Choose an image', onclick: URIWYSIWYG.mediaPicker},
+						{type: 'listbox', name: 'float', label: 'Alignment', value: args.float, 'values': [
+							{text: 'Auto', value: ''},
+							{text: 'Left', value: 'left'},
+							{text: 'Right', value: 'right'}
+						]
+						},
 					],
 					onsubmit: function(e) {
 						// Insert content when the window form is submitted

--- a/js/uri-hero-plugin.js
+++ b/js/uri-hero-plugin.js
@@ -52,14 +52,16 @@
 				// create an empty property so nothing is null
 				var possibleArgs = [
 						'img', 
+						'id',
 						'vid', 
-						'dynamic', 
 						'headline', 
 						'subhead', 
 						'link',
 						'button',
 						'tooltip',
-						'alt'
+						'alt',
+						'format',
+						'animation'
 				];
 				possibleArgs.forEach(function(i){
 					if(!args[i]) {
@@ -71,6 +73,11 @@
 				if(args.img) {
 					imageEl = '<img src="' + args.img + '" alt="' + args.alt + '" />';
 				}
+				
+				// Set an initial unique id for the hero component, since it's required
+				if (!args.id) { 
+					args.id = URIWYSIWYG.generateID();
+				}
 
 				ed.windowManager.open({
 					title: 'Insert / Update Hero',
@@ -78,21 +85,41 @@
 					body: [
 						{type: 'container', label: ' ', html: '<div id="wysiwyg-img-preview">' + imageEl + '</div>'},
 						{type: 'button', label: 'Image (required)', text: 'Choose an image', onclick: URIWYSIWYG.mediaPicker},
-						{type: 'checkbox', name: 'dynamic', label: 'Dynamic Zoom', checked: args.dynamic },
 						{type: 'textbox', name: 'alt', id: 'alt', value: args.alt, subtype: 'hidden'},
 						{type: 'textbox', name: 'img', id: 'img', value: args.img, subtype: 'hidden'},
+						{type: 'textbox', name: 'id', label: 'Unique ID', value: args.id},
 						{type: 'textbox', name: 'vid', label: 'YouTube ID', value: args.vid},
 		        		{type: 'textbox', name: 'headline', label: 'Headline', value: args.headline},
             			{type: 'textbox', multiline: 'true', name: 'subhead', label: 'Subheader', value: args.subhead},
 						{type: 'textbox', name: 'link', label: 'Link', value: args.link},
 						{type: 'textbox', name: 'button', label: 'Button Text', 'placeholder':'Explore', value: args.button},
-						{type: 'textbox', name: 'tooltip', label: 'Tooltip', value: args.tooltip}
+						{type: 'textbox', name: 'tooltip', label: 'Tooltip', value: args.tooltip},
+						{type: 'listbox', name: 'format', label: 'Format', value: args.format, 'values': [
+							{text: 'Default', value: ''},
+							{text: 'Full Width', value: 'fullwidth'},
+							{text: 'Super', value: 'super'}
+						]
+						},
+						{type: 'listbox', name: 'animation', label: 'Animation', value: args.animation, 'values': [
+							{text: 'None', value: ''},
+							{text: 'Shift', value: 'shift'}
+						]
+						},
 
 					],
 					onsubmit: function(e) {
+						
+						// Sanitize unique id
+						if (!e.data.id) { 
+							e.data.id = URIWYSIWYG.generateID();
+						} else {
+							e.data.id = e.data.id.replace(/\s/g, '');
+						}
+						
 						// Insert content when the window form is submitted
 						var shortcode = generateHeroShortcode(e.data);
 						URIWYSIWYG.insertMultiMediaComponent( target, shortcode, ed, cName );
+						
 					}
 				},
 				{

--- a/js/uri-hero-plugin.js
+++ b/js/uri-hero-plugin.js
@@ -3,11 +3,7 @@
 (function() {
 
 	var cName = 'cl-hero',
-			wName = 'CLHero';
-    
-	function renderHero( shortcode ) {
-
-	}
+		wName = 'CLHero';
 	
 	function generateHeroShortcode(params) {
 
@@ -47,7 +43,7 @@
 			});
 		
 			// add a js callback for the button
-			ed.addCommand(wName, function(args) {
+			ed.addCommand(wName, function( target, args ) {
 			
 				// create an empty object if args is empty
 				if(!args) {
@@ -86,8 +82,8 @@
 						{type: 'textbox', name: 'alt', id: 'alt', value: args.alt, subtype: 'hidden'},
 						{type: 'textbox', name: 'img', id: 'img', value: args.img, subtype: 'hidden'},
 						{type: 'textbox', name: 'vid', label: 'YouTube ID', value: args.vid},
-		        {type: 'textbox', name: 'headline', label: 'Headline', value: args.headline},
-            {type: 'textbox', multiline: 'true', name: 'subhead', label: 'Subheader', value: args.subhead},
+		        		{type: 'textbox', name: 'headline', label: 'Headline', value: args.headline},
+            			{type: 'textbox', multiline: 'true', name: 'subhead', label: 'Subheader', value: args.subhead},
 						{type: 'textbox', name: 'link', label: 'Link', value: args.link},
 						{type: 'textbox', name: 'button', label: 'Button Text', 'placeholder':'Explore', value: args.button},
 						{type: 'textbox', name: 'tooltip', label: 'Tooltip', value: args.tooltip}
@@ -95,8 +91,8 @@
 					],
 					onsubmit: function(e) {
 						// Insert content when the window form is submitted
-						shortcode = generateHeroShortcode(e.data);
-						ed.execCommand('mceInsertContent', 0, shortcode);
+						var shortcode = generateHeroShortcode(e.data);
+						URIWYSIWYG.insertMultiMediaComponent( target, shortcode, ed, cName );
 					}
 				},
 				{
@@ -106,7 +102,7 @@
 			});
 
 			ed.on( 'BeforeSetContent', function( event ) {
-				event.content = URIWYSIWYG.replaceShortcodes( event.content, cName, true, renderHero, ed );
+				event.content = URIWYSIWYG.replaceShortcodes( event.content, cName, true, ed );
 			});
 
 			ed.on( 'PostProcess', function( event ) {

--- a/js/uri-notice-plugin.js
+++ b/js/uri-notice-plugin.js
@@ -54,7 +54,7 @@
 					args = {}
 				}
 				// create an empty property so nothing is null
-				var possibleArgs = ['title', 'content', 'urgent'];
+				var possibleArgs = ['title', 'content', 'style'];
 				possibleArgs.forEach(function(i){
 					if(!args[i]) {
 						args[i] = '';
@@ -68,7 +68,11 @@
 					body: [
 						{type: 'textbox', name: 'title', label: 'Title', value: args.title},
 						{type: 'textbox', multiline: 'true', name: 'content', label: 'Content', value: args.content},
-						{type: 'checkbox', name: 'style', label: 'Urgent', checked: args.urgent }
+						{type: 'listbox', name: 'style', label: 'Style', value: args.style, 'values': [
+							{text: 'Default', value: ''},
+							{text: 'Urgent', value: 'urgent'}
+						]
+						},
 					],
 					onsubmit: function(e) {
 						// Insert content when the window form is submitted

--- a/js/uri-notice-plugin.js
+++ b/js/uri-notice-plugin.js
@@ -3,11 +3,8 @@
 (function() {
     
 	var cName = 'cl-notice',
-			wName = 'CLNotice';
+		wName = 'CLNotice';
 
-	function renderNotice( shortcode ) {
-	}
-	
 	function generateNoticeShortcode(params) {
 
 		var attributes = [];
@@ -50,7 +47,7 @@
 			});
 		
 			// add a js callback for the button
-			ed.addCommand(wName, function(args) {
+			ed.addCommand(wName, function( target, args ) {
 			
 				// create an empty object if args is empty
 				if(!args) {
@@ -86,7 +83,7 @@
 			});
             
 			ed.on( 'BeforeSetContent', function( event ) {
-				event.content = URIWYSIWYG.replaceShortcodes( event.content, cName, false, renderNotice, ed );
+				event.content = URIWYSIWYG.replaceShortcodes( event.content, cName, false, ed );
 			});
 
 			ed.on( 'PostProcess', function( event ) {

--- a/js/uri-panel-plugin.js
+++ b/js/uri-panel-plugin.js
@@ -3,10 +3,7 @@
 (function() {
 
 	var cName = 'cl-panel',
-			wName = 'CLPanel';
-    
-	function renderPanel( shortcode ) {
-	}
+		wName = 'CLPanel';
 	
 	function generatePanelShortcode(params) {
 
@@ -57,7 +54,7 @@
 			});
 		
 			// add a js callback for the button
-			ed.addCommand(wName, function(args) {
+			ed.addCommand(wName, function( target, args ) {
 
 				// create an empty object if args is empty
 				if(!args) {
@@ -92,8 +89,8 @@
 					],
 					onsubmit: function(e) {
 						// Insert content when the window form is submitted
-						shortcode = generatePanelShortcode(e.data);
-						ed.execCommand('mceInsertContent', 0, shortcode);
+						var shortcode = generatePanelShortcode(e.data);
+						URIWYSIWYG.insertMultiMediaComponent( target, shortcode, ed, cName );
 					}
 				},
 				{
@@ -103,7 +100,7 @@
 			});
             
 			ed.on( 'BeforeSetContent', function( event ) {
-				event.content = URIWYSIWYG.replaceShortcodes( event.content, cName, false, renderPanel, ed );
+				event.content = URIWYSIWYG.replaceShortcodes( event.content, cName, false, ed );
 			});
 
 			ed.on( 'PostProcess', function( event ) {

--- a/js/uri-tiles-plugin.js
+++ b/js/uri-tiles-plugin.js
@@ -63,7 +63,7 @@
 			});
 		
 			// add a js callback for the button
-			ed.addCommand(wName, function(args) {
+			ed.addCommand(wName, function( target, args ) {
 			
 				// create an empty object if args is empty
 				if(!args) {

--- a/js/uri-tiles-plugin.js
+++ b/js/uri-tiles-plugin.js
@@ -32,9 +32,6 @@
 			case '5': 
 			columns = 'fifths';
 			break;
-			case '6': 
-			columns = 'sixths';
-			break;
 		}
 		return columns;
 	}
@@ -87,7 +84,6 @@
 								{text: 'Three', value: '3'},
 								{text: 'Four', value: '4'},
 								{text: 'Five', value: '5'},
-								{text: 'Six', value: '6'}
 								]
 						},
 					],

--- a/js/uri-video-plugin.js
+++ b/js/uri-video-plugin.js
@@ -48,7 +48,7 @@
 					args = {}
 				}
 				// create an empty property so nothing is null
-				var possibleArgs = ['img', 'vid', 'alt', 'aspect'];
+				var possibleArgs = ['img', 'vid', 'alt', 'aspect', 'id', 'title', 'excerpt'];
 				possibleArgs.forEach(function(i){
 					if(!args[i]) {
 						args[i] = '';
@@ -61,6 +61,11 @@
 				if(args.img) {
 					imageEl = '<img src="' + args.img + '" alt="' + args.alt + '" />';
 				}
+				
+				// Set an initial unique id for the video component, since it's required
+				if (!args.id) { 
+					args.id = URIWYSIWYG.generateID();
+				}
 
 				ed.windowManager.open({
 					title: 'Insert / Update Video',
@@ -70,13 +75,25 @@
 						{type: 'button', label: 'Image (required)', text: 'Choose an image', onclick: URIWYSIWYG.mediaPicker},
 						{type: 'textbox', name: 'img', id: 'img', value: args.img, subtype: 'hidden'},
 						{type: 'textbox', name: 'alt', id: 'alt', label: 'Image Alt Text', value: args.alt},
+						{type: 'textbox', name: 'id', label: 'Unique ID', value: args.id},
 						{type: 'textbox', name: 'vid', label: 'YouTube ID', value: args.vid},
-						{type: 'textbox', name: 'aspect', label: 'Aspect Ratio', 'placeholder': '16:9', value: args.aspect}
+						{type: 'textbox', name: 'aspect', label: 'Aspect Ratio', 'placeholder': '16:9', value: args.aspect},
+						{type: 'textbox', name: 'title', label: 'Title', value: args.title},
+						{type: 'textbox', name: 'excerpt', multiline: 'true', label: 'Excerpt', value: args.excerpt}
 					],
 					onsubmit: function(e) {
+						
+						// Sanitize unique id
+						if (!e.data.id) { 
+							e.data.id = URIWYSIWYG.generateID();
+						} else {
+							e.data.id = e.data.id.replace(/\s/g, '');
+						}
+						
 						// Insert content when the window form is submitted
 						var shortcode = generateVideoShortcode(e.data);
 						URIWYSIWYG.insertMultiMediaComponent( target, shortcode, ed, cName );
+						
 					}
 				},
 				{

--- a/js/uri-video-plugin.js
+++ b/js/uri-video-plugin.js
@@ -3,10 +3,7 @@
 (function() {
 
 	var cName = 'cl-video',
-			wName = 'CLVideo';
-    
-	function renderVideo( shortcode ) {
-	}
+		wName = 'CLVideo';
 	
 	function generateVideoShortcode(params) {
 
@@ -44,7 +41,7 @@
 			});
 		
 			// add a js callback for the button
-			ed.addCommand(wName, function(args) {
+			ed.addCommand(wName, function( target, args ) {
 			
 				// create an empty object if args is empty
 				if(!args) {
@@ -78,8 +75,8 @@
 					],
 					onsubmit: function(e) {
 						// Insert content when the window form is submitted
-						shortcode = generateVideoShortcode(e.data);
-						ed.execCommand('mceInsertContent', 0, shortcode);
+						var shortcode = generateVideoShortcode(e.data);
+						URIWYSIWYG.insertMultiMediaComponent( target, shortcode, ed, cName );
 					}
 				},
 				{
@@ -89,7 +86,7 @@
 			});
 
 			ed.on( 'BeforeSetContent', function( event ) {
-				event.content = URIWYSIWYG.replaceShortcodes( event.content, cName, true, renderVideo, ed );
+				event.content = URIWYSIWYG.replaceShortcodes( event.content, cName, true, ed );
 			});
 
 			ed.on( 'PostProcess', function( event ) {

--- a/js/uri-wysiwyg-helpers.js
+++ b/js/uri-wysiwyg-helpers.js
@@ -96,12 +96,10 @@ class URIWYSIWYG {
 
 				if(ed.$) {
 			
-					var placeHolder = ed.$('#' + id);
-					console.log(id);
-					
+					var placeHolder = ed.$('#' + id);					
 					var d = document.createElement('div');
 					
-					if( data.match( 'class="cl-card' ) ) {
+					if( data.match( 'class="cl-card' ) || data.match( 'class="cl-dcard' ) ) {
 						// replace the <a class="cl-card"> element with a <div>
 						// because TinyMCE doesn't like block-level elements inside of inline elements
 						data = data.replace('<a ', '<div ');
@@ -134,9 +132,9 @@ class URIWYSIWYG {
 	 * @param content string The editor content
 	 * @param shortcodeName string The shortcode name
 	 * @param selfclosing bool Whether or not the shortcode is self-closing
-	 * @param callback function The callback function
+	 * @param ed obj The editor
 	 */
-	static replaceShortcodes( content, shortcodeName, selfclosing, callback, ed ) {
+	static replaceShortcodes( content, shortcodeName, selfclosing, ed ) {
 
 		var re = selfclosing ? new RegExp('\\[' + shortcodeName + '([^\\]]*)\\]', 'g') : new RegExp('\\[' + shortcodeName + '.+?\\[/' + shortcodeName + '\\]', 'g');
 
@@ -148,21 +146,29 @@ class URIWYSIWYG {
 			safeData = window.encodeURIComponent( match );
 			classes = 'mceNonEditable ' + shortcodeName;
 
-			// generate a random ID
 			var id = URIWYSIWYG.generateID();
-			out = '<div class="loading" data-shortcode="' + safeData + '" id="' + id + '">Loading...</div>';
+			out = URIWYSIWYG.generateLoadingDiv( safeData, id );
 			
-			console.log("replace", id);
 			URIWYSIWYG.getHTML( ed, match, id, classes );
-			callback( match, out, ed );
 			return out;
 
 		});
 	}
 	
 	
+	/* Generates a random ID
+	 */
 	static generateID() {
 		return '_' + Math.random().toString(36).substr(2, 9);
+	}
+	
+	
+	/* Generates the loading div
+	 * @param data str The shortcode data
+	 * @param id The random id
+	 */
+	static generateLoadingDiv( data, id ) {
+		return '<div class="loading" data-shortcode="' + data + '" id="' + id + '">Loading...</div>';	
 	}
 
 	
@@ -303,8 +309,6 @@ class URIWYSIWYG {
 				target = jQuery(target).closest( '.' + cName + '-wrapper' )[0];	
 			}
 			
-			console.log(target);
-
 			sc = window.decodeURIComponent( target.getAttribute('data-shortcode') );
 			attributes = URIWYSIWYG.parseShortCodeAttributes(sc);
 			ed.execCommand(wName, target, attributes);

--- a/js/uri-wysiwyg-helpers.js
+++ b/js/uri-wysiwyg-helpers.js
@@ -97,6 +97,7 @@ class URIWYSIWYG {
 				if(ed.$) {
 			
 					var placeHolder = ed.$('#' + id);
+					console.log(id);
 					
 					var d = document.createElement('div');
 					
@@ -148,14 +149,20 @@ class URIWYSIWYG {
 			classes = 'mceNonEditable ' + shortcodeName;
 
 			// generate a random ID
-			var id = '_' + Math.random().toString(36).substr(2, 9);
-			URIWYSIWYG.getHTML( ed, match, id, classes );
-		
+			var id = URIWYSIWYG.generateID();
 			out = '<div class="loading" data-shortcode="' + safeData + '" id="' + id + '">Loading...</div>';
+			
+			console.log("replace", id);
+			URIWYSIWYG.getHTML( ed, match, id, classes );
 			callback( match, out, ed );
 			return out;
 
 		});
+	}
+	
+	
+	static generateID() {
+		return '_' + Math.random().toString(36).substr(2, 9);
 	}
 
 	
@@ -295,10 +302,12 @@ class URIWYSIWYG {
 				// see if the component has a wrapper element
 				target = jQuery(target).closest( '.' + cName + '-wrapper' )[0];	
 			}
+			
+			console.log(target);
 
 			sc = window.decodeURIComponent( target.getAttribute('data-shortcode') );
 			attributes = URIWYSIWYG.parseShortCodeAttributes(sc);
-			ed.execCommand(wName, attributes);
+			ed.execCommand(wName, target, attributes);
 		}
    }
 	


### PR DESCRIPTION
Introduce a workaround for components using the WP media picker.  Essentially, the workaround bypasses using TinyMCE to update these components' html/shortcodes.

Also updates all components to comply with [CL 2.3.4](https://github.com/uriweb/uri-component-library/releases/tag/2.3.4).